### PR TITLE
Weak self

### DIFF
--- a/AsyncSequence/AsyncSequence.xcodeproj/project.pbxproj
+++ b/AsyncSequence/AsyncSequence.xcodeproj/project.pbxproj
@@ -444,7 +444,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -475,7 +475,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/structured-concurrency/structured-concurrency/View/AsyncLetView.swift
+++ b/structured-concurrency/structured-concurrency/View/AsyncLetView.swift
@@ -54,9 +54,9 @@ final class AsyncLetViewModel {
     struct InternalError: Error {}
 
     func showMypageData() {
-        Task { [weak self] in
-            let mypageData = await self?.fetchMyPageData()
-            print(mypageData ?? "")
+        Task {
+            let mypageData = await fetchMyPageData()
+            print(mypageData)
         }
     }
 

--- a/structured-concurrency/structured-concurrency/View/CancellationView.swift
+++ b/structured-concurrency/structured-concurrency/View/CancellationView.swift
@@ -59,9 +59,9 @@ final class CancellationViewModel: @unchecked Sendable {
     func fetchDataWithLongTask() async throws -> [String] {
         return await withThrowingTaskGroup(of: [String].self) { group in
 
-            group.addTask { [weak self] in
+            group.addTask {
                 try Task.checkCancellation()
-                await self?.veryLongTask()
+                await self.veryLongTask()
                 return ["a", "b"]
             }
 
@@ -78,8 +78,8 @@ final class CancellationViewModel: @unchecked Sendable {
         return try await withThrowingTaskGroup(of: UIImage.self) { group in
             for id in ids {
                 if Task.isCancelled { break }
-                group.addTask { [weak self] in
-                    return await self?.fetchImage(with: id) ?? UIImage()
+                group.addTask {
+                    return await self.fetchImage(with: id)
                 }
             }
             var icons: [UIImage] = []

--- a/structured-concurrency/structured-concurrency/View/TaskDetachedView.swift
+++ b/structured-concurrency/structured-concurrency/View/TaskDetachedView.swift
@@ -41,9 +41,12 @@ final class TaskDetachedViewModel {
     func didTapButton() {
         Task {
             // ログを送信
-            Task.detached(priority: .low) { [weak self] in
+            Task.detached(priority: .low) {
+                // Task.detachedのクロージャー内のself参照について
+                // https://github.com/apple/swift-evolution/blob/main/proposals/0304-structured-concurrency.md#implicit-self
+                // Task.detachedはすぐに実行され、実行完了後はクロージャーは開放されるのでselfとの循環参照の恐れがない。
+                // よって[weak self]でselfを弱参照する必要なし。そのまま`self.`でselfのメソッドにアクセスしてよい。
                 print("detached isMainThread: \(Thread.isMainThread)")
-                guard let self = self else { return }
                 async let _ = await self.sendLog(name: "didTapButton")
                 async let _ = await self.sendLog(name: "user is xxx")
             }

--- a/structured-concurrency/structured-concurrency/View/TaskView.swift
+++ b/structured-concurrency/structured-concurrency/View/TaskView.swift
@@ -61,6 +61,13 @@ final class TaskViewModel {
     }
 
     func fetchUserWithCheckCancellation() {
+        /**
+         Task.initのクロージャー内のself参照について
+         https://github.com/apple/swift-evolution/blob/main/proposals/0304-structured-concurrency.md#implicit-self
+         Task.initのクロージャーはすぐに実行され、実行完了後はクロージャーは開放されるのでselfとの循環参照の恐れがない。
+         よって[weak self]でselfを弱参照する必要なし。
+         さらにTask.initはTask.detachedとTaskGroup.addTaskと異なり @_implicitSelfCapture が機能しており、selfを書かなくてもselfのメソッドやプロパティにアクセスができる。
+         */
         task = Task {
             do {
                 let users = try await longTaskWithError()


### PR DESCRIPTION
* AsyncSequenceのビルドエラーを解消。
* AsyncSequenceで画面非表示にTaskをキャンセルする。
* Task.initとTask.detachedとTaskGroup.addTaskのクロージャーは[weak self]は不要。
    * クロージャーが即時に実行されるので、selfにアクセスしても問題ないため

参考
https://qiita.com/maiyama18/items/ab314e9d9b12b583c29b